### PR TITLE
manifest: Track proton clang

### DIFF
--- a/derp/derp.xml
+++ b/derp/derp.xml
@@ -150,6 +150,8 @@
   <project path="prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9" name="prebuilts_gcc_linux-x86_arm_arm-linux-androideabi-4.9" remote="derp" clone-depth="1" />
   <project path="prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8" name="prebuilts_gcc_linux-x86_host_x86_64-linux-glibc2.17-4.8" remote="derp" clone-depth="1" />
   <project path="prebuilts/tools-lineage" name="prebuilts_tools-derp" remote="derp" />
+  <project path="prebuilts/clang/host/linux-x86/clang-proton" name="kdrag0n/proton-clang"
+    remote="github" revision="master" clone-depth="1" />
 
   <!-- System -->
   <project path="system/bt" name="system_bt" remote="derp" />


### PR DESCRIPTION
Will make easier for maintainers, as lot of them use it as clang on their kernels