### PR TITLE
Track jemalloc from org (5/5)

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -293,7 +293,6 @@
   <project path="external/jazzer-api" name="platform/external/jazzer-api" groups="pdk" />
   <project path="external/jcommander" name="platform/external/jcommander" groups="pdk" />
   <project path="external/jdiff" name="platform/external/jdiff" groups="pdk" />
-  <project path="external/jemalloc_new" name="platform/external/jemalloc_new" groups="pdk" />
   <project path="external/jimfs" name="platform/external/jimfs" groups="pdk" />
   <project path="external/jline" name="platform/external/jline" groups="pdk,tradefed,pdk-fs" />
   <project path="external/jsilver" name="platform/external/jsilver" groups="pdk" />

--- a/snippets/derp.xml
+++ b/snippets/derp.xml
@@ -62,6 +62,7 @@
   <project path="external/FadingEdgeLayout" name="external_FadingEdgeLayout" remote="derp" />
   <project path="external/gptfdisk" name="external_gptfdisk" remote="derp" />
   <project path="external/json-c" name="external_json-c" groups="qcom,qssi" remote="derp" />
+  <project path="external/jemalloc_new" name="platform/external/jemalloc_new" groups="pdk" remote="derp" />
   <project path="external/libcxx" name="external_libcxx" groups="pdk" remote="derp" />
   <project path="external/libnl" name="external_libnl" groups="pdk" remote="derp" />
   <project path="external/libvpx" name="external_libvpx" groups="pdk" remote="derp" />


### PR DESCRIPTION
Jemalloc by default is good because of  : 

1. Reduced Fragmentation: jemalloc employs sophisticated algorithms to allocate memory in a way that minimizes fragmentation. This fragmentation occurs when freed memory becomes scattered in small chunks, making it difficult to allocate larger blocks efficiently. jemalloc's approach helps maintain contiguous memory regions, leading to faster allocation and deallocation operations.

2. jemalloc excels in multi-threaded environments. It utilizes thread-caching mechanisms and per-thread allocation arenas to minimize contention and improve memory access speed for concurrent threads.

3. jemalloc provides valuable debugging features that can aid in troubleshooting memory-related issues within the operating system. These tools can help pinpoint memory leaks, identify memory usage patterns, and diagnose allocation/deallocation problems, leading to a more stable and reliable system.

4. It also make's the device perform well at higer  load's and improve performance. 


You can check other PR regarding this from these Links.  

[Build_soong](https://github.com/DerpFest-AOSP/build_soong/pull/6) (2/5)
[Bionic](https://github.com/DerpFest-AOSP/bionic/pull/3) (3/5)
[external_jemalloc_new](https://github.com/DerpFest-AOSP/external_jemalloc_new/pull/1) (4/5)
[manifest](https://github.com/DerpFest-AOSP/manifest/pulls/21) (5/5)